### PR TITLE
emoved unnecessary commented-out code for maintainability [xml:S125]

### DIFF
--- a/src/main/assets/vtm/vtmstyle.xml
+++ b/src/main/assets/vtm/vtmstyle.xml
@@ -1027,14 +1027,7 @@
                         stipple-width="0.8" stroke="#aaa6a4" width="2.0" />
                 </m>
 
-                <!-- <m v="rail" zoom-max="14" zoom-min="13">
-                  <line stroke="#8888aa" width="0.6" cap="butt"
-                  fix="true" />
-                  </m> -->
-                <!-- <m v="rail" zoom-max="13" zoom-min="11">
-                  <line stroke="#bbbbcc" width="0.8" cap="butt" fix="true" />
-                  </m> -->
-                <!-- whatever railway:spur means ... -->
+                
                 <m v="disused|spur|abandoned|preserved">
                     <line cap="butt" fade="12" fix="true" stroke="#cccccc" width="0.8" />
                 </m>


### PR DESCRIPTION
## Technical Debt Fix: Removing Commented-Out Code

- This PR removes unnecessary commented-out code in `src/main/assets/vtm/vtmstyle.xml`.
- Fixes SonarQube issue **xml:S125**.
- Improves maintainability and code clarity.

### Changes:
- Removed all unnecessary commented-out lines.
- Ensured the file remains functional.

**Issue Reference:** (If you created an issue earlier, link it using `Fixes #<issue-number>`)

**Tested:** ✅ Yes (Verified file changes)