### PR TITLE
Fix: Secure broadcast receiver with custom permission (CWE-280 fix)

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+>
+    <permission
+            android:name="de.storchp.opentracks.osmplugin.permission.DOWNLOAD_COMPLETE"
+            android:protectionLevel="signature" />
 
     <application
         android:name=".Startup"

--- a/src/main/kotlin/de/storchp/opentracks/osmplugin/download/DownloadActivity.kt
+++ b/src/main/kotlin/de/storchp/opentracks/osmplugin/download/DownloadActivity.kt
@@ -168,14 +168,20 @@ class DownloadActivity : BaseActivity() {
                 registerReceiver(
                     downloadBroadcastReceiver,
                     IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
+                    "de.storchp.opentracks.osmplugin.permission.DOWNLOAD_COMPLETE",
+                    null,
                     RECEIVER_EXPORTED
                 )
             } else {
+                @Suppress("DEPRECATION")
                 registerReceiver(
                     downloadBroadcastReceiver,
-                    IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
+                    IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
+                    "de.storchp.opentracks.osmplugin.permission.DOWNLOAD_COMPLETE",
+                    null
                 )
             }
+
 
             startDownload()
         } else {


### PR DESCRIPTION
## Fix: Secure Broadcast Receiver (CWE-280 via Snyk)

### Vulnerability Summary:
This PR fixes a security vulnerability (CWE-280) detected by Snyk in `DownloadActivity.kt`.  
The issue was that `registerReceiver()` was called without a broadcast permission, making the app vulnerable to malicious broadcasts pretending to be from the system.

### Fix Implemented:
- Declared a custom permission `de.storchp.opentracks.osmplugin.permission.DOWNLOAD_COMPLETE` in `AndroidManifest.xml`
- Updated `registerReceiver()` to securely use this permission
- Ensured compatibility with Android versions above and below API level 33 (Tiramisu)

### References:
- CWE-280: https://cwe.mitre.org/data/definitions/280.html
- Snyk Report Screenshot: (attach screenshot in the case study report)


